### PR TITLE
Fix include no host

### DIFF
--- a/EventListener/JmsSerializeListenerAbstract.php
+++ b/EventListener/JmsSerializeListenerAbstract.php
@@ -115,10 +115,7 @@ class JmsSerializeListenerAbstract
             /** @var array $filters */
             foreach ($filters as $filter) {
                 $result[$filter] = $this->cacheManager->getBrowserPath($value, $filter);
-
-                if (array_key_exists('includeHost', $this->config) && !$this->config['includeHost']) {
-                    $result[$filter] = $this->stripHostFromUrl($result[$filter]);
-                }
+                $result[$filter] = $this->checkIncludeHostForUrl($result[$filter]);
             }
 
             return $result;
@@ -126,12 +123,7 @@ class JmsSerializeListenerAbstract
 
         $filtered = $this->cacheManager->getBrowserPath($value, $filters);
         if (count($result) !== 0) {
-            $result[$filters] = $filtered;
-
-            if (array_key_exists('includeHost', $this->config) && !$this->config['includeHost']) {
-                $result[$filters] = $this->stripHostFromUrl($result[$filters]);
-            }
-
+            $result[$filters] = $this->checkIncludeHostForUrl($filtered);
             return $result;
         }
 
@@ -157,6 +149,21 @@ class JmsSerializeListenerAbstract
     }
 
     /**
+     * If config demands, it will remove host and scheme (protocol) from passed url
+     *
+     * @param $url
+     * @return string
+     */
+    private function checkIncludeHostForUrl($url)
+    {
+        if (array_key_exists('includeHost', $this->config) && !$this->config['includeHost']) {
+            $url = $this->stripHostFromUrl($url);
+        }
+
+        return $url;
+    }
+
+    /**
      * Removes host and scheme (protocol) from passed url
      *
      * @param $url
@@ -165,9 +172,9 @@ class JmsSerializeListenerAbstract
     private function stripHostFromUrl($url)
     {
         $parts = parse_url($url);
-        if (isset ($parts['path'])) {
-            if (isset ($parts['query'])) {
-                return $parts['path'] . '?' . $parts['query'];
+        if (isset($parts['path'])) {
+            if (array_key_exists('query', $parts)) {
+                return $parts['path'].'?'.$parts['query'];
             } else {
                 return $parts['path'];
             }

--- a/EventListener/JmsSerializeListenerAbstract.php
+++ b/EventListener/JmsSerializeListenerAbstract.php
@@ -124,6 +124,7 @@ class JmsSerializeListenerAbstract
         $filtered = $this->cacheManager->getBrowserPath($value, $filters);
         if (count($result) !== 0) {
             $result[$filters] = $this->checkIncludeHostForUrl($filtered);
+
             return $result;
         }
 

--- a/EventListener/JmsSerializeListenerAbstract.php
+++ b/EventListener/JmsSerializeListenerAbstract.php
@@ -115,6 +115,10 @@ class JmsSerializeListenerAbstract
             /** @var array $filters */
             foreach ($filters as $filter) {
                 $result[$filter] = $this->cacheManager->getBrowserPath($value, $filter);
+
+                if (array_key_exists('includeHost', $this->config) && !$this->config['includeHost']) {
+                    $result[$filter] = $this->stripHostFromUrl($result[$filter]);
+                }
             }
 
             return $result;
@@ -123,6 +127,10 @@ class JmsSerializeListenerAbstract
         $filtered = $this->cacheManager->getBrowserPath($value, $filters);
         if (count($result) !== 0) {
             $result[$filters] = $filtered;
+
+            if (array_key_exists('includeHost', $this->config) && !$this->config['includeHost']) {
+                $result[$filters] = $this->stripHostFromUrl($result[$filters]);
+            }
 
             return $result;
         }
@@ -146,5 +154,23 @@ class JmsSerializeListenerAbstract
         }
 
         return $url;
+    }
+
+    /**
+     * Removes host and scheme (protocol) from passed url
+     *
+     * @param $url
+     * @return string
+     */
+    private function stripHostFromUrl($url)
+    {
+        $parts = parse_url($url);
+        if (isset ($parts['path'])) {
+            if (isset ($parts['query'])) {
+                return $parts['path'] . '?' . $parts['query'];
+            } else {
+                return $parts['path'];
+            }
+        }
     }
 }

--- a/Tests/EventListener/JmsSerializeListenerTest.php
+++ b/Tests/EventListener/JmsSerializeListenerTest.php
@@ -100,7 +100,7 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
 
         static::assertJson($result);
         $data = json_decode($result, true);
-        static::assertEquals('http://example.com/a/path/to/an/image3.png', $data['imageThumb']);
+        static::assertEquals('http://example.com:8800/a/path/to/an/image3.png', $data['imageThumb']);
     }
 
     /**
@@ -113,8 +113,8 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
         $this->generateRequestContext();
         $this->eventManager->addEventListeners($this->requestContext, $this->cacheManager, $this->vichStorage);
         $this->eventManager->dispatchEvents($this->context, $user);
-        static::assertEquals('http://example.com/a/path/to/an/image1.png', $user->getCoverUrl());
-        static::assertEquals('http://example.com/a/path/to/an/image2.png', $user->getPhotoName());
+        static::assertEquals('http://example.com:8800/a/path/to/an/image1.png', $user->getCoverUrl());
+        static::assertEquals('http://example.com:8800/a/path/to/an/image2.png', $user->getPhotoName());
     }
 
     /**
@@ -128,10 +128,10 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
         $this->eventManager->addEventListeners($this->requestContext, $this->cacheManager, $this->vichStorage);
         $data = $this->serializeObject($userPictures);
 
-        static::assertEquals('http://example.com/a/path/to/an/image1.png', $data['cover']['big']);
-        static::assertEquals('http://example.com/a/path/to/an/image2.png', $data['cover']['small']);
+        static::assertEquals('http://example.com:8800/a/path/to/an/image1.png', $data['cover']['big']);
+        static::assertEquals('http://example.com:8800/a/path/to/an/image2.png', $data['cover']['small']);
         static::assertEquals('http://example.com:8000/uploads/photo.jpg', $data['photo']);
-        static::assertEquals('http://example.com/a/path/to/an/image3.png', $data['photoThumb']);
+        static::assertEquals('http://example.com:8800/a/path/to/an/image3.png', $data['photoThumb']);
     }
 
     /**
@@ -149,9 +149,9 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
         ]);
 
         static::assertEquals('https://example.com:8800/uploads/photo.jpg', $data['photo']);
-        static::assertEquals('http://example.com/a/path/to/an/image1.png', $data['cover']['big']);
-        static::assertEquals('http://example.com/a/path/to/an/image2.png', $data['cover']['small']);
-        static::assertEquals('http://example.com/a/path/to/an/image3.png', $data['photoThumb']['thumb_filter']);
+        static::assertEquals('http://example.com:8800/a/path/to/an/image1.png', $data['cover']['big']);
+        static::assertEquals('http://example.com:8800/a/path/to/an/image2.png', $data['cover']['small']);
+        static::assertEquals('http://example.com:8800/a/path/to/an/image3.png', $data['photoThumb']['thumb_filter']);
         static::assertEquals('/uploads/photo.jpg', $data['photoThumb']['original']);
     }
 
@@ -211,6 +211,68 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
         static::assertEquals('https://example.com:8800/uploads/photo.jpg', $data['photo']);
         static::assertFalse(strpos($data['cover']['original'], 'https://example.com:8800'));
         static::assertEquals('https://example.com:8800/uploads/photo.jpg', $data['photoThumb']['original']);
+    }
+
+    /**
+     * Test serialization with host in url and host in url for original and non-stored (resolve path) images
+     */
+    public function testSerializationWithHostAndHostForOriginalAndNonStoredImages()
+    {
+        $userPhotos = new UserPhotos();
+        $this->generateCacheManager('https://example.com:8800/', false);
+        $this->generateRequestContext(true, true);
+        $data = $this->serializeObject($userPhotos, [
+            'includeHost' => true,
+            'vichUploaderSerialize' => true,
+            'includeOriginal' => true,
+            'includeHostForOriginal' => true,
+        ]);
+
+        static::assertEquals('https://example.com:8800/a/path/to/an/resolve/image1.png', $data['cover']['big']);
+        static::assertEquals('https://example.com:8800/a/path/to/an/resolve/image2.png', $data['cover']['small']);
+        static::assertEquals('https://example.com:8800/uploads/photo.jpg', $data['photo']);
+        static::assertFalse(strpos($data['cover']['original'], 'https://example.com:8800'));
+        static::assertEquals('https://example.com:8800/uploads/photo.jpg', $data['photoThumb']['original']);
+    }
+
+    /**
+     * Test serialization with no host in url and no host in url for original and non-stored (resolve path) images
+     */
+    public function testSerializationWithNoHostAndNoHostForOriginalAndNonStoredImages()
+    {
+        $userPhotos = new UserPhotos();
+        $this->generateCacheManager('https://example.com:8800/', false);
+        $this->generateRequestContext(true, true);
+        $data = $this->serializeObject($userPhotos, [
+            'includeHost' => false,
+            'vichUploaderSerialize' => true,
+            'includeOriginal' => true,
+            'includeHostForOriginal' => false,
+        ]);
+
+        static::assertEquals('/a/path/to/an/resolve/image1.png', $data['cover']['big']);
+        static::assertEquals('/a/path/to/an/resolve/image2.png', $data['cover']['small']);
+        static::assertEquals('/uploads/photo.jpg', $data['photo']);
+        static::assertEquals('/uploads/photo.jpg', $data['photoThumb']['original']);
+    }
+
+    /**
+     * Test serialization with no host in url and no host in url for original and ONE non-stored (resolve path) image
+     */
+    public function testSerializationWithNoHostAndNoHostForOriginalAndOneNonStoredImage()
+    {
+        $userPictures = new UserPictures();
+        $this->generateCacheManager('https://example.com:8800/', false);
+        $this->generateRequestContext(true, true);
+        $data = $this->serializeObject($userPictures, [
+            'includeHost' => false,
+            'vichUploaderSerialize' => true,
+            'includeOriginal' => true,
+            'includeHostForOriginal' => false,
+        ]);
+
+        static::assertEquals('/uploads/photo.jpg', $data['photoThumb']['original']);
+        static::assertEquals('/a/path/to/an/resolve/image3.png', $data['photoThumb']['thumb_filter']);
     }
 
     /**
@@ -291,14 +353,15 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
      * Prepare mock of Liip cache manager
      *
      * @param string $urlPrefix
+     * @param bool $isStored
      */
-    protected function generateCacheManager($urlPrefix = 'http://example.com/')
+    protected function generateCacheManager($urlPrefix = 'http://example.com:8800/', $isStored = true)
     {
         $resolver = $this->getMockBuilder('Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface')->getMock();
         $resolver
             ->expects(static::any())
             ->method('isStored')
-            ->will(static::returnValue(true))
+            ->will(static::returnValue($isStored))
         ;
         $resolver
             ->expects(static::any())
@@ -317,8 +380,9 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $router = $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')->getMock();
-        $router->expects(static::never())
+        $router->expects(static::any())
             ->method('generate')
+            ->will(static::onConsecutiveCalls($urlPrefix.'a/path/to/an/resolve/image1.png', $urlPrefix.'a/path/to/an/resolve/image2.png', $urlPrefix.'a/path/to/an/resolve/image3.png', $urlPrefix.'a/path/to/an/resole/image4.png'))
         ;
 
         $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();

--- a/Tests/EventListener/JmsSerializeListenerTest.php
+++ b/Tests/EventListener/JmsSerializeListenerTest.php
@@ -100,7 +100,7 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
 
         static::assertJson($result);
         $data = json_decode($result, true);
-        static::assertEquals('http://a/path/to/an/image3.png', $data['imageThumb']);
+        static::assertEquals('http://example.com/a/path/to/an/image3.png', $data['imageThumb']);
     }
 
     /**
@@ -113,8 +113,8 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
         $this->generateRequestContext();
         $this->eventManager->addEventListeners($this->requestContext, $this->cacheManager, $this->vichStorage);
         $this->eventManager->dispatchEvents($this->context, $user);
-        static::assertEquals('http://a/path/to/an/image1.png', $user->getCoverUrl());
-        static::assertEquals('http://a/path/to/an/image2.png', $user->getPhotoName());
+        static::assertEquals('http://example.com/a/path/to/an/image1.png', $user->getCoverUrl());
+        static::assertEquals('http://example.com/a/path/to/an/image2.png', $user->getPhotoName());
     }
 
     /**
@@ -128,10 +128,10 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
         $this->eventManager->addEventListeners($this->requestContext, $this->cacheManager, $this->vichStorage);
         $data = $this->serializeObject($userPictures);
 
-        static::assertEquals('http://a/path/to/an/image1.png', $data['cover']['big']);
-        static::assertEquals('http://a/path/to/an/image2.png', $data['cover']['small']);
+        static::assertEquals('http://example.com/a/path/to/an/image1.png', $data['cover']['big']);
+        static::assertEquals('http://example.com/a/path/to/an/image2.png', $data['cover']['small']);
         static::assertEquals('http://example.com:8000/uploads/photo.jpg', $data['photo']);
-        static::assertEquals('http://a/path/to/an/image3.png', $data['photoThumb']);
+        static::assertEquals('http://example.com/a/path/to/an/image3.png', $data['photoThumb']);
     }
 
     /**
@@ -149,9 +149,9 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
         ]);
 
         static::assertEquals('https://example.com:8800/uploads/photo.jpg', $data['photo']);
-        static::assertEquals('http://a/path/to/an/image1.png', $data['cover']['big']);
-        static::assertEquals('http://a/path/to/an/image2.png', $data['cover']['small']);
-        static::assertEquals('http://a/path/to/an/image3.png', $data['photoThumb']['thumb_filter']);
+        static::assertEquals('http://example.com/a/path/to/an/image1.png', $data['cover']['big']);
+        static::assertEquals('http://example.com/a/path/to/an/image2.png', $data['cover']['small']);
+        static::assertEquals('http://example.com/a/path/to/an/image3.png', $data['photoThumb']['thumb_filter']);
         static::assertEquals('/uploads/photo.jpg', $data['photoThumb']['original']);
     }
 
@@ -292,7 +292,7 @@ class JmsSerializeListenerTest extends \PHPUnit_Framework_TestCase
      *
      * @param string $urlPrefix
      */
-    protected function generateCacheManager($urlPrefix = 'http://')
+    protected function generateCacheManager($urlPrefix = 'http://example.com/')
     {
         $resolver = $this->getMockBuilder('Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface')->getMock();
         $resolver


### PR DESCRIPTION
**Issue**: includeHost=false not working for thumbnails generated from filters
(https://github.com/Bukashk0zzz/LiipImagineSerializationBundle/issues/1)

The phpunit tests didn't catch this case, as they only checked for "already stored" images. I included cases to check for generated images/thumbs. Checks Annotation: for multiple filters specified as array and a single filter as string.

I didn't find a way to get CacheManager->getBrowserPath to only return the relative path, it always returns the absolute path by default. So my change strips the host and protocol in case includeHost=false.