### PR TITLE
[Bugfix] Serialize a list with same image

### DIFF
--- a/EventListener/JmsPreSerializeListener.php
+++ b/EventListener/JmsPreSerializeListener.php
@@ -62,7 +62,8 @@ class JmsPreSerializeListener extends JmsSerializeListenerAbstract
                             $vichAnnotation = $this->annotationReader->getPropertyAnnotation($vichProperty, UploadableField::class);
                             $cacheKey = $vichField.\array_pop($uriComponents).$vichAnnotation->getMapping();
 
-                            if (\in_array($cacheKey, $this->cache, true)) {
+                            if (array_key_exists($cacheKey, $this->cache)) {
+                                $property->setValue($object, $this->cache[$cacheKey]);
                                 continue;
                             }
                         }
@@ -79,7 +80,7 @@ class JmsPreSerializeListener extends JmsSerializeListenerAbstract
                         }
 
                         if ($vichField) {
-                            $this->cache[] = $cacheKey;
+                            $this->cache[$cacheKey] = $property->getValue($object);
                         }
                     }
                 }

--- a/EventListener/JmsPreSerializeListener.php
+++ b/EventListener/JmsPreSerializeListener.php
@@ -62,7 +62,7 @@ class JmsPreSerializeListener extends JmsSerializeListenerAbstract
                             $vichAnnotation = $this->annotationReader->getPropertyAnnotation($vichProperty, UploadableField::class);
                             $cacheKey = $vichField.\array_pop($uriComponents).$vichAnnotation->getMapping();
 
-                            if (array_key_exists($cacheKey, $this->cache)) {
+                            if (\array_key_exists($cacheKey, $this->cache)) {
                                 $property->setValue($object, $this->cache[$cacheKey]);
                                 continue;
                             }


### PR DESCRIPTION
Case : serialize, mutliple object with same image and multiple liipfilter.

Explaination :
When i serialize a list with same image, i'v got a trouble with JMS, it's return string and not array for same object and same value (for exemple picture with default.png).

After a really quick analyse, i find that JmsPreSerializeListener skip the transformation string to array (for multiple liipfilter) if the cache key is the same. So i put in cache array the property value (same object, same filter, same value ?) and it's resolve my trouble.

Open to exchange on this issues :)

