### PR TITLE
Fix annotation reader dependency

### DIFF
--- a/EventListener/JmsSerializeListenerAbstract.php
+++ b/EventListener/JmsSerializeListenerAbstract.php
@@ -14,7 +14,7 @@ use Bukashk0zzz\LiipImagineSerializationBundle\Annotation\LiipImagineSerializabl
 use Bukashk0zzz\LiipImagineSerializationBundle\Event\UrlNormalizerEvent;
 use Bukashk0zzz\LiipImagineSerializationBundle\Normalizer\UrlNormalizerInterface;
 use Doctrine\Common\Annotations\CachedReader;
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\Proxy;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;

--- a/EventListener/JmsSerializeListenerAbstract.php
+++ b/EventListener/JmsSerializeListenerAbstract.php
@@ -13,7 +13,7 @@ namespace Bukashk0zzz\LiipImagineSerializationBundle\EventListener;
 use Bukashk0zzz\LiipImagineSerializationBundle\Annotation\LiipImagineSerializableField;
 use Bukashk0zzz\LiipImagineSerializationBundle\Event\UrlNormalizerEvent;
 use Bukashk0zzz\LiipImagineSerializationBundle\Normalizer\UrlNormalizerInterface;
-use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\Reader;
 use Doctrine\Persistence\Proxy;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
@@ -32,7 +32,7 @@ class JmsSerializeListenerAbstract
     protected $requestContext;
 
     /**
-     * @var CachedReader Cached annotation reader
+     * @var Reader Annotation reader
      */
     protected $annotationReader;
 
@@ -63,7 +63,7 @@ class JmsSerializeListenerAbstract
      */
     public function __construct(
         RequestContext $requestContext,
-        CachedReader $annotationReader,
+        Reader $annotationReader,
         CacheManager $cacheManager,
         StorageInterface $vichStorage,
         EventDispatcherInterface $eventDispatcher,

--- a/Tests/EventListener/JmsSerializeEventsManager.php
+++ b/Tests/EventListener/JmsSerializeEventsManager.php
@@ -16,8 +16,6 @@ use Bukashk0zzz\LiipImagineSerializationBundle\Tests\EventSubscriber\Bukashk0zzz
 use Bukashk0zzz\LiipImagineSerializationBundle\Tests\Fixtures\User;
 use Bukashk0zzz\LiipImagineSerializationBundle\Tests\Fixtures\UserPictures;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\CachedReader;
-use Doctrine\Common\Cache\ArrayCache;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\EventDispatcher\EventDispatcher;
 use JMS\Serializer\EventDispatcher\Events as JmsEvents;
@@ -38,7 +36,7 @@ class JmsSerializeEventsManager
     private $dispatcher;
 
     /**
-     * @var CachedReader Cached annotation reader
+     * @var AnnotationReader Annotation reader
      */
     private $annotationReader;
 
@@ -52,7 +50,7 @@ class JmsSerializeEventsManager
      */
     public function __construct()
     {
-        $this->annotationReader = new CachedReader(new AnnotationReader(), new ArrayCache());
+        $this->annotationReader = new AnnotationReader();
         $this->symfonyEventDispatcher = new SymfonyEventDispatcher();
     }
 

--- a/Tests/Fixtures/UserPictures.php
+++ b/Tests/Fixtures/UserPictures.php
@@ -12,7 +12,7 @@
 namespace Bukashk0zzz\LiipImagineSerializationBundle\Tests\Fixtures;
 
 use Bukashk0zzz\LiipImagineSerializationBundle\Annotation as Bukashk0zzz;
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\Proxy;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as JMS;
 use Symfony\Component\HttpFoundation\File\File;


### PR DESCRIPTION
Require `Doctrine\Common\Annotations\Reader` interface instead of `Doctrine\Common\Annotations\CachedReader` implementation (which is also [deprecated](https://github.com/doctrine/annotations/blob/732ea120f89e570dd63828b91af83a1b48e21dfb/lib/Doctrine/Common/Annotations/CachedReader.php#L20-L22)).

Fixes #23